### PR TITLE
fix(streak): preserve daily streaks across midnight boundaries

### DIFF
--- a/src/components/game/ResultsCard.tsx
+++ b/src/components/game/ResultsCard.tsx
@@ -11,6 +11,7 @@ import { saveGameResult, migrateLocalStorageToSupabase, calculatePoints, saveArc
 import { useToast } from "@/hooks/use-toast";
 import { RippleCelebration } from "./RippleCelebration";
 import { trackEvent } from "@/lib/analytics";
+import { getDateInHST } from "@/lib/utils";
 
 interface ResultsCardProps {
   dayNumber: number;
@@ -37,10 +38,11 @@ export const ResultsCard = ({
   const [showLoginPrompt, setShowLoginPrompt] = useState(false);
   const [hasSaved, setHasSaved] = useState(false);
   const hasTrackedCompletion = useRef(false);
+  const completionDate = useRef(getDateInHST());
   const { user } = useAuth();
   const { toast } = useToast();
   const navigate = useNavigate();
-  
+
   const correctCount = answers.filter(Boolean).length;
   const totalCount = answers.length;
   const points = calculatePoints(answers, hintUsedOnEvent);
@@ -54,7 +56,7 @@ export const ResultsCard = ({
         userId: user?.id,
         metadata: { dayNumber, points, correctCount, hintUsed, isArchive }
       });
-      
+
       // Also track archive-specific completion for funnel analysis
       if (isArchive) {
         trackEvent('archive_puzzle_completed', {
@@ -69,31 +71,48 @@ export const ResultsCard = ({
   useEffect(() => {
     const handleUserData = async () => {
       if (user && !hasSaved) {
-        // First, try to migrate localStorage data (only for daily puzzles)
-        if (!isArchive) {
-          const didMigrate = await migrateLocalStorageToSupabase(user.id);
-          
-          if (didMigrate) {
-            toast({
-              title: "Progress saved!",
-              description: "Your previous game data has been synced to your account.",
-            });
+        try {
+          // First, try to migrate localStorage data (only for daily puzzles)
+          if (!isArchive) {
+            const didMigrate = await migrateLocalStorageToSupabase(user.id);
+
+            if (didMigrate) {
+              toast({
+                title: "Progress saved!",
+                description: "Your previous game data has been synced to your account.",
+              });
+            }
           }
+
+          /**
+           * Save game result to Supabase.
+           * Archive plays are tracked for history but don't affect streaks.
+           */
+          const didSave = isArchive
+            ? await saveArchiveGameResult(user.id, dayNumber, answers, hintUsed, hintUsedOnEvent)
+            : await saveGameResult(user.id, dayNumber, answers, hintUsed, hintUsedOnEvent, completionDate.current);
+
+          if (!didSave) {
+            toast({
+              title: "Sync issue",
+              description: "We couldn't save this result to your account right now.",
+              variant: "destructive",
+            });
+            return;
+          }
+
+          setHasSaved(true);
+        } catch (error) {
+          console.error('Error syncing game result:', error);
+          toast({
+            title: "Sync issue",
+            description: "We couldn't sync your result. Please try refreshing and signing in again.",
+            variant: "destructive",
+          });
         }
-        
-        /**
-         * Save game result to Supabase.
-         * Archive plays are tracked for history but don't affect streaks.
-         */
-        if (isArchive) {
-          await saveArchiveGameResult(user.id, dayNumber, answers, hintUsed, hintUsedOnEvent);
-        } else {
-          await saveGameResult(user.id, dayNumber, answers, hintUsed, hintUsedOnEvent);
-        }
-        setHasSaved(true);
       }
     };
-    
+
     handleUserData();
   }, [user, dayNumber, answers, hintUsed, hintUsedOnEvent, hasSaved, toast, isArchive]);
 
@@ -143,7 +162,7 @@ export const ResultsCard = ({
           </CardTitle>
           <p className="text-muted-foreground">{puzzleTitle}</p>
         </CardHeader>
-        
+
         <CardContent className="space-y-6">
           {/* Score display with points */}
           <div className="text-center">
@@ -175,8 +194,8 @@ export const ResultsCard = ({
                     "w-12 h-12 rounded-full flex items-center justify-center text-lg font-semibold transition-all",
                     usedHintOnThis
                       ? "bg-hint text-hint-foreground"
-                      : correct 
-                        ? "bg-correct text-correct-foreground" 
+                      : correct
+                        ? "bg-correct text-correct-foreground"
                         : "bg-incorrect text-incorrect-foreground"
                   )}
                 >
@@ -190,43 +209,43 @@ export const ResultsCard = ({
           <div className="flex flex-col gap-3">
             {/* Primary CTA - Keep Playing (daily puzzles) or Back to Archive (archive puzzles) */}
             {isArchive ? (
-              <Button 
-                onClick={() => navigate('/archive')} 
-                size="lg" 
+              <Button
+                onClick={() => navigate('/archive')}
+                size="lg"
                 className="w-full gap-2"
               >
                 <ArrowLeft className="w-5 h-5" />
                 Back to Archive
               </Button>
             ) : (
-              <Button 
+              <Button
                 onClick={() => {
                   trackEvent('archive_cta_clicked', {
                     metadata: { from: 'results_page', day_number: dayNumber }
                   });
                   navigate('/archive');
-                }} 
-                size="lg" 
+                }}
+                size="lg"
                 className="w-full gap-2"
               >
                 <Library className="w-5 h-5" />
                 Keep Playing — Explore Past Puzzles
               </Button>
             )}
-            
+
             {/* Secondary Actions - Side by Side */}
             <div className="flex gap-3">
-              <Button 
-                onClick={onShowStats} 
-                variant="outline" 
+              <Button
+                onClick={onShowStats}
+                variant="outline"
                 className="flex-1 gap-2"
               >
                 <BarChart3 className="w-4 h-4" />
                 Stats
               </Button>
-              <Button 
-                onClick={handleShare} 
-                variant="outline" 
+              <Button
+                onClick={handleShare}
+                variant="outline"
                 className="flex-1 gap-2"
               >
                 {copied ? <Check className="w-4 h-4" /> : <Share2 className="w-4 h-4" />}
@@ -237,7 +256,7 @@ export const ResultsCard = ({
 
           {/* Next puzzle countdown - only for today's puzzle */}
           {!isArchive && <CountdownToMidnight />}
-          
+
           {/* Info for archive puzzles */}
           {isArchive && (
             <div className="text-center pt-4 border-t border-border">
@@ -294,7 +313,7 @@ const CountdownToMidnight = () => {
  */
 function getTimeUntilMidnightHST(): string {
   const now = new Date();
-  
+
   // Get the current time in HST
   const hstFormatter = new Intl.DateTimeFormat('en-US', {
     timeZone: 'Pacific/Honolulu',
@@ -306,23 +325,23 @@ function getTimeUntilMidnightHST(): string {
     second: '2-digit',
     hour12: false,
   });
-  
+
   const parts = hstFormatter.formatToParts(now);
   const getPart = (type: string) => parts.find(p => p.type === type)?.value || '0';
-  
+
   const hstHours = parseInt(getPart('hour'), 10);
   const hstMinutes = parseInt(getPart('minute'), 10);
   const hstSeconds = parseInt(getPart('second'), 10);
-  
+
   // Calculate seconds until midnight HST
-  const secondsUntilMidnight = 
-    (24 - hstHours - 1) * 3600 + 
-    (60 - hstMinutes - 1) * 60 + 
+  const secondsUntilMidnight =
+    (24 - hstHours - 1) * 3600 +
+    (60 - hstMinutes - 1) * 60 +
     (60 - hstSeconds);
-  
+
   const hours = Math.floor(secondsUntilMidnight / 3600);
   const minutes = Math.floor((secondsUntilMidnight % 3600) / 60);
   const seconds = secondsUntilMidnight % 60;
-  
+
   return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
 }

--- a/src/lib/supabaseStats.ts
+++ b/src/lib/supabaseStats.ts
@@ -1,6 +1,6 @@
 import { supabase } from '@/integrations/supabase/client';
 import { getStats, getGameState, GameStats, GameState } from './storage';
-import { getDateInHST, getYesterdayInHST } from './utils';
+import { getDateInHST } from './utils';
 
 export interface SupabaseUserStats {
   user_id: string;
@@ -76,11 +76,11 @@ export const getPercentileMessage = (percentile: number, hintUsed: boolean, poin
   if (points === 300) {
     return "🎯 Perfect score! No hints needed!";
   }
-  
+
   if (hintUsed && percentile >= 70) {
     return `Top ${100 - Math.floor(percentile)}% even with a lifeline — nice!`;
   }
-  
+
   if (percentile >= 90) {
     return "🌟 Outstanding! You're in the top 10% today!";
   }
@@ -103,12 +103,12 @@ export const fetchUserStats = async (userId: string): Promise<SupabaseUserStats 
     .select('*')
     .eq('user_id', userId)
     .maybeSingle();
-  
+
   if (error) {
     console.error('Error fetching user stats:', error);
     return null;
   }
-  
+
   return data;
 };
 
@@ -123,12 +123,12 @@ export const hasPlayedPuzzle = async (userId: string, dayNumber: number): Promis
     .eq('user_id', userId)
     .eq('day_number', dayNumber)
     .maybeSingle();
-  
+
   if (error) {
     console.error('Error checking if played puzzle:', error);
     return false;
   }
-  
+
   return !!data;
 };
 
@@ -270,11 +270,12 @@ export const saveGameResult = async (
   dayNumber: number,
   answers: boolean[],
   hintUsed: boolean,
-  hintUsedOnEvent: number | null
+  hintUsedOnEvent: number | null,
+  playedDate: string = getDateInHST()
 ): Promise<boolean> => {
   const score = answers.filter(Boolean).length;
   const points = calculatePoints(answers, hintUsedOnEvent);
-  
+
   const { error } = await supabase
     .from('game_results')
     .upsert({
@@ -288,15 +289,15 @@ export const saveGameResult = async (
     }, {
       onConflict: 'user_id,day_number',
     });
-  
+
   if (error) {
     console.error('Error saving game result:', error);
     return false;
   }
-  
+
   // Update user stats (affects streaks for daily puzzles)
-  await updateUserStats(userId, answers, points);
-  
+  await updateUserStats(userId, answers, points, playedDate);
+
   return true;
 };
 
@@ -317,7 +318,7 @@ export const saveArchiveGameResult = async (
 ): Promise<boolean> => {
   const score = answers.filter(Boolean).length;
   const points = calculatePoints(answers, hintUsedOnEvent);
-  
+
   const { error } = await supabase
     .from('game_results')
     .upsert({
@@ -331,41 +332,47 @@ export const saveArchiveGameResult = async (
     }, {
       onConflict: 'user_id,day_number',
     });
-  
+
   if (error) {
     console.error('Error saving archive game result:', error);
     return false;
   }
-  
+
   // NOTE: We intentionally DO NOT call updateUserStats here
   // because archive plays should not affect streaks or daily stats
-  
+
   return true;
 };
 
 // Update user stats after game
-export const updateUserStats = async (userId: string, answers: boolean[], points: number): Promise<void> => {
-  // Use HST dates to match the game's daily reset at midnight HST
-  const today = getDateInHST();
+export const updateUserStats = async (
+  userId: string,
+  answers: boolean[],
+  points: number,
+  playedDate: string = getDateInHST()
+): Promise<void> => {
+  const today = playedDate;
   const correctCount = answers.filter(Boolean).length;
-  
+
   // Get existing stats
   const existingStats = await fetchUserStats(userId);
-  
+
   if (existingStats) {
     // Check if already counted today (in HST)
     if (existingStats.last_played_date === today) {
       return;
     }
-    
-    // Calculate streak using HST dates
-    const yesterdayStr = getYesterdayInHST();
-    
+
+    // Derive "yesterday" from the same played date to avoid midnight race conditions.
+    const d = new Date(`${today}T12:00:00`);
+    d.setDate(d.getDate() - 1);
+    const yesterdayStr = getDateInHST(d);
+
     let newStreak = 1;
     if (existingStats.last_played_date === yesterdayStr) {
       newStreak = existingStats.current_streak + 1;
     }
-    
+
     const { error } = await supabase
       .from('user_stats')
       .update({
@@ -378,7 +385,7 @@ export const updateUserStats = async (userId: string, answers: boolean[], points
         last_played_date: today,
       })
       .eq('user_id', userId);
-    
+
     if (error) {
       console.error('Error updating user stats:', error);
     }
@@ -396,7 +403,7 @@ export const updateUserStats = async (userId: string, answers: boolean[], points
         total_points: points,
         last_played_date: today,
       });
-    
+
     if (error) {
       console.error('Error creating user stats:', error);
     }
@@ -407,15 +414,15 @@ export const updateUserStats = async (userId: string, answers: boolean[], points
 export const migrateLocalStorageToSupabase = async (userId: string): Promise<boolean> => {
   const localStats = getStats();
   const localGameState = getGameState();
-  
+
   // Check if user already has stats in Supabase
   const existingStats = await fetchUserStats(userId);
-  
+
   if (existingStats && existingStats.games_played > 0) {
     // User already has data in Supabase, don't overwrite
     return false;
   }
-  
+
   // Only migrate if there's local data
   if (localStats.gamesPlayed === 0) {
     return false;
@@ -423,7 +430,7 @@ export const migrateLocalStorageToSupabase = async (userId: string): Promise<boo
 
   // Estimate total points from local data (approximate)
   const estimatedPoints = localStats.totalCorrect * 100;
-  
+
   // Create user stats from local data
   const { error: statsError } = await supabase
     .from('user_stats')
@@ -435,14 +442,15 @@ export const migrateLocalStorageToSupabase = async (userId: string): Promise<boo
       total_correct: localStats.totalCorrect,
       total_events: localStats.totalEvents,
       total_points: estimatedPoints,
-      last_played_date: localStats.lastPlayedDate ? getDateInHST(new Date(localStats.lastPlayedDate)) : null,
+      // Local stats already store HST YYYY-MM-DD. Re-parsing shifts the date in some timezones.
+      last_played_date: localStats.lastPlayedDate || null,
     });
-  
+
   if (statsError) {
     console.error('Error migrating stats:', statsError);
     return false;
   }
-  
+
   // If current game is complete, save that result too
   if (localGameState.isComplete && localGameState.answers.length > 0) {
     const answers = localGameState.answers.filter((a): a is boolean => a !== null);
@@ -454,16 +462,16 @@ export const migrateLocalStorageToSupabase = async (userId: string): Promise<boo
       localGameState.hintUsedOnEvent
     );
   }
-  
+
   return true;
 };
 
 // Convert Supabase stats to local GameStats format for UI compatibility
 export const convertToGameStats = (stats: SupabaseUserStats): GameStats => {
-  const successRate = stats.total_events > 0 
-    ? Math.round((stats.total_correct / stats.total_events) * 100) 
+  const successRate = stats.total_events > 0
+    ? Math.round((stats.total_correct / stats.total_events) * 100)
     : 0;
-  
+
   return {
     gamesPlayed: stats.games_played,
     currentStreak: stats.current_streak,


### PR DESCRIPTION
I usually play around midnight (Hawaiian time), and it doesn't store my streak. It did so in the past.

In case the core issue is in the sync path, for example because a date is already stored in normalised HST string format, then it might get parsed again as a Date and then re-normalised, which could shift it to the previous day. Once `last_played_date` is wrong in `Supabase`, streak continuation logic evaluates against the wrong reference day and reset/increment behaviour becomes inconsistent.

### What might solve it:

Stop reparsing migrated `lastPlayedDate` values; persist the normalised date string directly. Add a stable `playedDate` flow for save/update operations so streak maths uses the puzzle _completion day_, not a later async execution time. Derive “yesterday” from that same stable `playedDate` to avoid midnight rollover race conditions. Update result-save flow to pass the captured completion date through to stats persistence. Harden migration/save error handling so sync failures are surfaced instead of silently masking stale streak data.

### Why these steps:

Date normalisation must be idempotent. Re-interpreting an already normalised day string introduced timezone drift. Streak logic depends on exact calendar-day transitions, so all calculations must share one authoritative day value. Async network timing should not change outcomes; capturing completion-time context makes behaviour deterministic. Better error visibility improves trust and allows us to diagnose sync/state issues instead of silently resetting the streak.